### PR TITLE
Added missing JAXB maven dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,26 @@
       		<version>4.12</version>
       		<scope>test</scope>
     	</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.2.11</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
     </dependencies>
 
 	<developers>


### PR DESCRIPTION
JAXB has been removed from the JRE/JDK as of V9 and only natively exists
in JEE. Maven dependencies are required.

Hi, looking forward to playing around and moving this project forward.